### PR TITLE
Fix selector of comment textarea

### DIFF
--- a/test/zendesk-incident-protector.spec.js
+++ b/test/zendesk-incident-protector.spec.js
@@ -18,7 +18,7 @@ const { JSDOM } = jsdom;
 const defaultDOM = new JSDOM(`
 <!-- comment textarea -->
 <div class="comment_input_wrapper">
-  <div class="fr-focus">
+  <div class="comment_input">
     <div class="content">
       <div class="header">
         <span class="ember-view btn track-id-publicComment active"></span>
@@ -300,10 +300,26 @@ describe('NGWordValidator', () => {
   const targetWords = ['test', 'memo', '(aaa|xxx)', 'HOGE-\\d+', '\\(bbb\\|yyy\\)'];
   const locale      = 'ja';
 
+  // NOTE:
+  // mock UI_CONSTANTS, because :visible is not supported in jsdom
+  // ref. https://github.com/tmpvar/jsdom/issues/1048
+  const mockUIConstants = {
+    selector: {
+      commentActionTarget: 'div.comment_input_wrapper div.comment_input div.content div.header span.active',
+      commentTextArea: 'div.comment_input_wrapper div.comment_input div.content div.body div.ember-view div.editor div.zendesk-editor--rich-text-comment'
+    },
+    attribute: {
+      publicCommentClass: 'track-id-publicComment'
+    }
+  }
+
   let ngWordValidator;
 
   beforeEach(() => {
     ngWordValidator = new NGWordValidator(targetDOM, targetWords, locale);
+    sinon.stub(NGWordValidator, 'UI_CONSTANTS').get(function getterFn() {
+      return mockUIConstants;
+    });
   });
 
   describe('isPublicResponse', () => {
@@ -354,7 +370,7 @@ describe('NGWordValidator', () => {
   });
 
   describe('createConfirmText', () => {
-    const text = $(NGWordValidator.UI_CONSTANTS.selector.commentTextArea).text();
+    const text = $(mockUIConstants.selector.commentTextArea).text();
     const expectedText = 'testmessage';
 
     it('returns confirm text', () => {

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -184,8 +184,8 @@
     static get UI_CONSTANTS() {
       return {
         selector: {
-          commentActionTarget: 'div.comment_input_wrapper div.fr-focus div.content div.header span.active',
-          commentTextArea: 'div.comment_input_wrapper div.fr-focus div.content div.body div.ember-view div.editor div.zendesk-editor--rich-text-comment'
+          commentActionTarget: 'div.comment_input_wrapper div.comment_input:visible div.content div.header span.active',
+          commentTextArea: 'div.comment_input_wrapper div.comment_input:visible div.content div.body div.ember-view div.editor div.zendesk-editor--rich-text-comment'
         },
         attribute: {
           publicCommentClass: 'track-id-publicComment'

--- a/zendesk-incident-protector.user.js
+++ b/zendesk-incident-protector.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name           Zendesk Incident Protector
-// @version        1.0.1
+// @version        1.0.2
 // @description    Prevent replying to customer with specific NG keywords
 // @author         XFLAG Studio CRE Team
 // @include        https://*.zendesk.com/*


### PR DESCRIPTION
When "close tab" (which located on submit button) selected, I found that userscript does not work.

![image](https://user-images.githubusercontent.com/5433425/57998245-979cc080-7b0b-11e9-8925-b637cf8c5345.png)

Around this operation, `fr-focus` class has been removed from `div` component. 
So I fixed selector of comment textarea.

**before click**

![image](https://user-images.githubusercontent.com/5433425/57994782-c742cd00-7af9-11e9-8b84-b2fe0be8f387.png)

**after click**

![image](https://user-images.githubusercontent.com/5433425/57994552-aded5100-7af8-11e9-94a3-49b7cad3ea1b.png)
