### PR TITLE
CIの修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: circleci/node:8.9.3
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
```
いつも CircleCI をご利用いただきありがとうございます。
11 月 1 日より Docker Hub で匿名ユーザーによるイメージのプル リクエストに対する 回数制限が導入されます。そこで、想定される影響やワークフロー中断の回避策について、ユーザーの皆様にお知らせいたします。
サービス中断を回避するには、パイプラインの構成に Docker の認証を追加する方法が最も簡単です。CircleCI で Docker Executor をお使いの場合や、 machine Executor を使用して Docker イメージをプルしている場合は、認証を行っていただくことをお勧めします。匿名ユーザーによる API リクエストの回数制限は IP アドレスに基づいて適用されるため、クラウド版 CircleCI をご利用のお客様に影響が生じると見られます。認証済みのユーザーに対しては、IP に関係なく、ユーザーごとの回数制限が緩和されます。
現在 CircleCI は、この変更に伴うユーザーの皆様への影響を最小限に抑えるために Docker 社 と連携して対応しております。さらに詳しい情報が出てまいりましたら、お知らせいたします。
ご不明な点やご質問などがございましたら、 CircleCI Discuss をご覧になるか、 サポート チームまでお問い合わせください。
今後とも CircleCI をご活用くださいますようお願いいたします。
- CircleCI チーム
```

こちらへの対応です。